### PR TITLE
ninja-fix – use `self.load_from_repository(version)` instead of `repository.setup(version)` directly (for polymorphism)

### DIFF
--- a/ccmlib/cluster.py
+++ b/ccmlib/cluster.py
@@ -134,7 +134,7 @@ class Cluster(object):
             common.validate_install_dir(install_dir)
             self.__version = self.__get_version_from_build()
         else:
-            dir, v = repository.setup(version, verbose)
+            dir, v = self.load_from_repository(version, verbose)
             self.__install_dir = dir
             self.__version = v if v is not None else self.__get_version_from_build()
             if not isinstance(self.__version, LooseVersion):

--- a/ccmlib/node.py
+++ b/ccmlib/node.py
@@ -497,6 +497,11 @@ class Node(object):
         self.__update_status()
         return self.status == Status.UP
 
+    def is_converged_core(self):
+        """ TODO modularise out to separate cluster type under "cc/" (when conditionals tech debt costs) """
+        dse_db_jar = glob.glob(os.path.join(self.get_install_dir(), '**', 'dse-db-*.jar'), recursive=True)
+        return dse_db_jar and 0 < len(dse_db_jar)
+
     def log_directory(self):
         return os.path.join(self.get_path(), 'logs')
 
@@ -1214,6 +1219,8 @@ class Node(object):
     def clear(self, clear_all=False, only_data=False):
         data_dirs = ['data{0}'.format(x) for x in xrange(0, self.cluster.data_dir_count)]
         data_dirs.append("commitlogs")
+        if self.is_converged_core():
+            data_dirs.append("metadata")
         if clear_all:
             data_dirs.extend(['saved_caches', 'logs'])
         for d in data_dirs:
@@ -1792,7 +1799,7 @@ class Node(object):
         data['commitlog_directory'] = os.path.join(self.get_path(), 'commitlogs')
         data['saved_caches_directory'] = os.path.join(self.get_path(), 'saved_caches')
 
-        if 'metadata_directory' in data:
+        if self.is_converged_core():
             data['metadata_directory'] = os.path.join(self.get_path(), 'metadata')
 
         if self.get_cassandra_version() > '3.0' and 'hints_directory' in yaml_text:


### PR DESCRIPTION
this commit will get merged into `apache/cassandra-ccm@trunk`
and cherry-picked into `datastax/cassandra-ccm@converged-core`, with rebase notes in the commit message (that it can be removed on next upstream rebase)