### PR TITLE
CNDB-17227 Load dse credentials in load_from_repository

### DIFF
--- a/ccmlib/dse/dse_cluster.py
+++ b/ccmlib/dse/dse_cluster.py
@@ -118,6 +118,12 @@ class DseCluster(Cluster):
         # during upgrade tests (which doesn't call __init__)
         if not hasattr(self, 'dse_username') or self.dse_username is None:
             self.load_credentials_from_file(None)
+            if not self.dse_username or not self.dse_password:
+                raise ValueError(
+                    f"DSE credentials not found. Ensure ~/.ccm/.dse.ini exists with valid credentials. "
+                    f"Current state: dse_username={'SET' if self.dse_username else 'NOT SET'}, "
+                    f"dse_password={'SET' if self.dse_password else 'NOT SET'}"
+                )
 
         if self.opscenter is not None:
             odir = setup_opscenter(self.opscenter, self.dse_username, self.dse_password, verbose)

--- a/ccmlib/dse/dse_cluster.py
+++ b/ccmlib/dse/dse_cluster.py
@@ -113,6 +113,12 @@ class DseCluster(Cluster):
         super(DseCluster, self).__init__(path, name, partitioner, install_dir, create_directory, version, verbose, options=options)
 
     def load_from_repository(self, version, verbose):
+        # Load DSE credentials from .dse.ini if not already set
+        # This is needed when the cluster class is changed from Cluster to DseCluster
+        # during upgrade tests (which doesn't call __init__)
+        if not hasattr(self, 'dse_username') or self.dse_username is None:
+            self.load_credentials_from_file(None)
+
         if self.opscenter is not None:
             odir = setup_opscenter(self.opscenter, self.dse_username, self.dse_password, verbose)
             target_dir = os.path.join(self.get_path(), 'opscenter')


### PR DESCRIPTION
During upgrade tests, when a Cluster object's class is changed to DseCluster (e.g., cluster.__class__ = DseCluster), Python does not call DseCluster.__init__(). This means load_credentials_from_file() is never called, resulting in None values for dse_username and dse_password.

This causes DSE downloads to fail with HTTP 401 errors because credentials are not available when setup_dse() is called.

Fix: Load credentials from ~/.ccm/.dse.ini at the start of load_from_repository() if they are not already set. This ensures credentials are available before downloading DSE, regardless of whether __init__() was called.

This fix is specifically needed for upgrade test scenarios where:
1. Tests create a Cassandra cluster (Cluster.__init__ called)
2. Tests change cluster.__class__ to DseCluster (no __init__ call)
3. Tests call load_from_repository() to download DSE