### PR TITLE
Add pyproject.toml and pin pbr to fix build failure caused by pbr 7.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,3 @@
+[build-system]
+requires = ["setuptools>=62", "pbr>=5.8.1"]
+build-backend = "setuptools.build_meta"

--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,7 @@ if system() == "Windows":
     ccmscript = 'ccm.py'
 
 setup(
-    setup_requires=['pbr>=5.8.1'],
+    setup_requires=['pbr>=5.8.1,<7.1'],
     scripts=[ccmscript],
     pbr=True,
 )


### PR DESCRIPTION
The ccm package fails to install with:

    ModuleNotFoundError: No module named 'setuptools.command.build'

Root cause: setup_requires=['pbr>=5.8.1'] in setup.py fetches the latest pbr from PyPI at build time. pbr 7.1.0 (released August 2025) introduced a regression in its find_sources() code path that crashes when invoked via the legacy `python setup.py egg_info` path that pip falls back to when no pyproject.toml is present.

Fix 1 — add pyproject.toml declaring the PEP 517 build backend:

    [build-system]
    requires = ["setuptools>=62", "pbr>=5.8.1"]
    build-backend = "setuptools.build_meta"

pip then calls setuptools.build_meta directly instead of invoking `python setup.py egg_info`, bypassing the broken pbr 7.1.x code path. This protects all modern pip installs (pip >= 21.3).

Fix 2 — pin pbr<7.1 in setup.py setup_requires:

    setup_requires=['pbr>=5.8.1,<7.1']

This protects legacy install paths (python setup.py install, pip < 21.3 editable installs) which still invoke setup.py directly and would otherwise pick up the broken pbr 7.1.x from PyPI. pbr 7.0.3 and earlier are unaffected.

setup.py is otherwise kept as-is to preserve compatibility with editable installs on older pip versions and direct invocation outside of pip. No changes to setup.cfg or requirements.txt are needed.

Opened CC PR to kick off the CI run: https://github.com/datastax/cassandra/pull/2593.